### PR TITLE
Prevents the truncation of trailing zeros in chapter numbers (Untested)

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ program
 					//Match chapter
 					entry.chapter = options.chapter_regex.exec(file);
 					if (entry.chapter && entry.chapter.length >= 2) {
-						entry.chapter = parseFloat(entry.chapter[1].replace('x', '.').replace('p', '.'));
+						entry.chapter = entry.chapter[1].replace('x', '.').replace('p', '.').split(".").map((x)=>parseInt(x)).join(".");
 					} else { entry.chapter = 0; }
 
 					//Title-regex supplied? -> Match title


### PR DESCRIPTION
Treat the "." in chapter numbers as a separator
e.g. `7.10` is parsed as `7.10` instead of `7.1`