### PR TITLE
Remove `parseFloat()` from chapter parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ program
 					//Match chapter
 					entry.chapter = options.chapter_regex.exec(file);
 					if (entry.chapter && entry.chapter.length >= 2) {
-						entry.chapter = parseFloat(entry.chapter[1].replace('x', '.').replace('p', '.'));
+						entry.chapter = entry.chapter[1].replace('x', '.').replace('p', '.');
 					} else { entry.chapter = 0; }
 
 					//Title-regex supplied? -> Match title


### PR DESCRIPTION
Mangadex removes zero-padding from the primary chapter numbering so this is no longer necessary. Also fixes a bug where trailing zeros were removed from the secondary numbers. e.g. `7.10` => `7.1`