### PR TITLE
Volume defaults to -1 instead of 0 if regex fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ program
 					let volume_result = options.volume_regex.exec(file);
 					if (volume_result && volume_result.length >= 2) {
 						entry.volume = parseInt(volume_result[1]);
-					} else { entry.volume = 0; }
+					} else { entry.volume = -1; }
 
 					//Match chapter
 					let chapter_result = options.chapter_regex.exec(file);


### PR DESCRIPTION
0 is a valid volume number and doesn't result in a blank volume field.
https://github.com/xicelord/mangadex-bulkuploader/blob/40de7a2b7f7419f0d1d670feb5a38f6fc60b6b46/index.js#L453